### PR TITLE
Add missing quotes around undefined in auth.tsx

### DIFF
--- a/auth.tsx
+++ b/auth.tsx
@@ -10,7 +10,7 @@ export function AuthProvider({ children }: any) {
   const [user, setUser] = useState<firebaseClient.User | null>(null);
 
   useEffect(() => {
-    if (typeof window !== undefined) {
+    if (typeof window !== "undefined") {
       (window as any).nookies = nookies;
     }
     return firebaseClient.auth().onIdTokenChanged(async (user) => {


### PR DESCRIPTION
Thanks for a brilliant tutorial/solution! 🙏 Just one possible issue - the expression `typeof window !== undefined` in `auth.tsx` will always evaluate to `true` without quotes.